### PR TITLE
Call addRef when returning an interface

### DIFF
--- a/vst3-derive/src/derive.rs
+++ b/vst3-derive/src/derive.rs
@@ -124,6 +124,8 @@ impl<'a> Vst3Impl<'a> {
                     }
                     if #( #is_equal_iid )||* {
                         *ppv = this as *mut std::os::raw::c_void;
+                        let this = &*(this as *const Self);
+                        this.#refcount.add_ref();
                         0
                     } else {
                         *ppv = std::ptr::null_mut();


### PR DESCRIPTION
According to the SDK, the method `queryInterface` of `FUnknown` should call `addRef` when returning an interface.
The absence of this call causes crashes on many hosts and on the validator.